### PR TITLE
Issue 12 update php codesniffer

### DIFF
--- a/coder_sniffer/Backdrop/Sniffs/Arrays/ArraySniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Arrays/ArraySniff.php
@@ -20,7 +20,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Array_ArraySniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ArraySniff implements Sniff
 {
 
 
@@ -45,11 +52,11 @@ class Backdrop_Sniffs_Array_ArraySniff implements PHP_CodeSniffer_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens   = $phpcsFile->getTokens();
         $lastItem = $phpcsFile->findPrevious(
-            PHP_CodeSniffer_Tokens::$emptyTokens,
+            Tokens::$emptyTokens,
             ($tokens[$stackPtr]['parenthesis_closer'] - 1),
             $stackPtr,
             true
@@ -67,12 +74,13 @@ class Backdrop_Sniffs_Array_ArraySniff implements PHP_CodeSniffer_Sniff
         if ($tokens[$lastItem]['code'] !== T_COMMA && $isInlineArray === false
             && $tokens[($lastItem + 1)]['code'] !== T_CLOSE_PARENTHESIS
         ) {
-            $phpcsFile->addWarning('A comma should follow the last multiline array item. Found: '.$tokens[$lastItem]['content'], $lastItem);
+
+            $phpcsFile->addWarning('A comma should follow the last multiline array item. Found: '.$tokens[$lastItem]['content'], $lastItem, 'MissingComma');
             return;
         }
 
         if ($tokens[$lastItem]['code'] === T_COMMA && $isInlineArray === true) {
-            $phpcsFile->addWarning('Last item of an inline array must not be followed by a comma', $lastItem);
+            $phpcsFile->addWarning('Last item of an inline array must not be followed by a comma', $lastItem, 'ExtraComma');
         }
 
         if ($isInlineArray === true) {
@@ -84,7 +92,7 @@ class Backdrop_Sniffs_Array_ArraySniff implements PHP_CodeSniffer_Sniff
                     $comma2 = $phpcsFile->findNext(T_COMMA, ($comma1 + 1), $tokens[$stackPtr]['parenthesis_closer']);
                     if ($comma2 !== false) {
                         $error = 'If the line declaring an array spans longer than 80 characters, each element should be broken into its own line';
-                        $phpcsFile->addError($error, $stackPtr, 'LongLineDeclaration');
+                        $phpcsFile->addError($error, $stackPtr, 'LongLineDeclaration', 'ArrayTooLong');
                     }
                 }
             }
@@ -132,7 +140,7 @@ class Backdrop_Sniffs_Array_ArraySniff implements PHP_CodeSniffer_Sniff
             $newLineStart = $lineStart;
             while ($tokens[$newLineStart]['line'] == $tokens[$lineStart]['line']) {
                 $newLineStart = $phpcsFile->findNext(
-                    PHP_CodeSniffer_Tokens::$emptyTokens,
+                    Tokens::$emptyTokens,
                     ($newLineStart + 1),
                     ($tokens[$stackPtr]['parenthesis_closer'] + 1),
                     true

--- a/coder_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
@@ -18,7 +18,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_CSS_ClassDefinitionClosingBraceSpaceSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\CSS;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ClassDefinitionClosingBraceSpaceSniff implements Sniff
 {
 
     /**
@@ -50,7 +57,7 @@ class Backdrop_Sniffs_CSS_ClassDefinitionClosingBraceSpaceSniff implements PHP_C
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -61,7 +68,7 @@ class Backdrop_Sniffs_CSS_ClassDefinitionClosingBraceSpaceSniff implements PHP_C
             return;
         }
 
-        $prev = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prev !== false && $tokens[$prev]['line'] !== ($tokens[$stackPtr]['line'] - 1)) {
             $error = 'Expected exactly one new line before closing brace of class definition';
             $phpcsFile->addError($error, $stackPtr, 'SpacingBeforeClose');

--- a/coder_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
@@ -18,7 +18,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_CSS_ClassDefinitionNameSpacingSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\CSS;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassDefinitionNameSpacingSniff implements Sniff
 {
 
     /**
@@ -50,7 +56,7 @@ class Backdrop_Sniffs_CSS_ClassDefinitionNameSpacingSniff implements PHP_CodeSni
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/coder_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
@@ -18,7 +18,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_CSS_ClassDefinitionOpeningBraceSpaceSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\CSS;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassDefinitionOpeningBraceSpaceSniff implements Sniff
 {
 
     /**
@@ -50,7 +56,7 @@ class Backdrop_Sniffs_CSS_ClassDefinitionOpeningBraceSpaceSniff implements PHP_C
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/coder_sniffer/Backdrop/Sniffs/CSS/ColourDefinitionSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/CSS/ColourDefinitionSniff.php
@@ -18,7 +18,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_CSS_ColourDefinitionSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\CSS;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ColourDefinitionSniff implements Sniff
 {
 
     /**
@@ -50,7 +56,7 @@ class Backdrop_Sniffs_CSS_ColourDefinitionSniff implements PHP_CodeSniffer_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $colour = $tokens[$stackPtr]['content'];

--- a/coder_sniffer/Backdrop/Sniffs/CSS/IndentationSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/CSS/IndentationSniff.php
@@ -17,7 +17,12 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_CSS_IndentationSniff implements PHP_CodeSniffer_Sniff
+namespace Backdrop\Sniffs\CSS;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class IndentationSniff implements Sniff
 {
 
     /**
@@ -56,7 +61,7 @@ class Backdrop_Sniffs_CSS_IndentationSniff implements PHP_CodeSniffer_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/coder_sniffer/Backdrop/Sniffs/Classes/ClassCreateInstanceSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Classes/ClassCreateInstanceSniff.php
@@ -20,7 +20,13 @@
  * @author    Peter Philipp <peter.philipp@cando-image.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Classes_ClassCreateInstanceSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassCreateInstanceSniff implements Sniff
 {
 
 
@@ -47,20 +53,20 @@ class Backdrop_Sniffs_Classes_ClassCreateInstanceSniff implements PHP_CodeSniffe
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         $nextParenthesis = $phpcsFile->findNext(array(T_OPEN_PARENTHESIS,T_SEMICOLON), $stackPtr, null, false, null, true);
         if ($tokens[$nextParenthesis]['code'] != T_OPEN_PARENTHESIS || $tokens[$nextParenthesis]['line'] != $tokens[$stackPtr]['line']) {
             $error  = 'Calling class constructors must always include parentheses';
-            $phpcsFile->addError($error, $nextParenthesis);
+            $phpcsFile->addError($error, $nextParenthesis, 'ClassConstructor');
             return;
         }
         
         if ($tokens[$nextParenthesis-1]['code'] == T_WHITESPACE) {
             $error  = 'Between the class name and the opening parenthesis spaces are not welcome';
-            $phpcsFile->addError($error, $nextParenthesis-1);
+            $phpcsFile->addError($error, $nextParenthesis-1, 'SpaceAfterClassName');
             return;
         }
     }//end process()

--- a/coder_sniffer/Backdrop/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Classes/ClassDeclarationSniff.php
@@ -27,7 +27,13 @@
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassDeclarationSniff implements Sniff
 {
 
 
@@ -55,7 +61,7 @@ class Backdrop_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_S
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -63,7 +69,7 @@ class Backdrop_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_S
             $error  = 'Possible parse error: ';
             $error .= $tokens[$stackPtr]['content'];
             $error .= ' missing opening or closing brace';
-            $phpcsFile->addWarning($error, $stackPtr);
+            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace');
             return;
         }
 
@@ -75,7 +81,7 @@ class Backdrop_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_S
             $error  = 'Opening brace of a ';
             $error .= $tokens[$stackPtr]['content'];
             $error .= ' must be on the same line as the definition';
-            $phpcsFile->addError($error, $curlyBrace);
+            $phpcsFile->addError($error, $curlyBrace, 'OpeningBrace');
             return;
         } /* else if ($braceLine > ($classLine + 1)) {
             $difference  = ($braceLine - $classLine - 1);
@@ -92,7 +98,7 @@ class Backdrop_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_S
         if ($tokens[($curlyBrace + 1)]['content'] !== $phpcsFile->eolChar && $tokens[($curlyBrace + 1)]['code'] !== T_CLOSE_CURLY_BRACKET) {
             $type  = strtolower($tokens[$stackPtr]['content']);
             $error = "Opening $type brace must be on a line by itself";
-            $phpcsFile->addError($error, $curlyBrace);
+            $phpcsFile->addError($error, $curlyBrace, 'OpeningBrace');
         }
 
         if ($tokens[($curlyBrace - 1)]['code'] != T_WHITESPACE) {
@@ -102,7 +108,7 @@ class Backdrop_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_S
                 $spaces     = strlen($blankSpace);
                 if ($spaces !== 0) {
                     $error = "Expected 1 space before opening brace; $spaces found";
-                    $phpcsFile->addError($error, $curlyBrace);
+                    $phpcsFile->addError($error, $curlyBrace, 'OpeningBrace');
                 }
             }
         }

--- a/coder_sniffer/Backdrop/Sniffs/Classes/InterfaceNameSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Classes/InterfaceNameSniff.php
@@ -16,7 +16,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Classes_InterfaceNameSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class InterfaceNameSniff implements Sniff
 {
 
 
@@ -41,7 +47,7 @@ class Backdrop_Sniffs_Classes_InterfaceNameSniff implements PHP_CodeSniffer_Snif
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens  = $phpcsFile->getTokens();
         $namePtr = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);

--- a/coder_sniffer/Backdrop/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -19,8 +19,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Commenting_DocCommentAlignmentSniff implements
-PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class Backdrop_Sniffs_Commenting_DocCommentAlignmentSniff implements Sniff
 {
 
 
@@ -45,12 +51,12 @@ PHP_CodeSniffer_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         // We are only interested in function/class/interface doc block comments.
-        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         $ignore    = array(
                       T_CLASS,
                       T_INTERFACE,
@@ -64,7 +70,7 @@ PHP_CodeSniffer_Sniff
 
         if (in_array($tokens[$nextToken]['code'], $ignore) === false) {
             // Could be a file comment.
-            $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if ($tokens[$prevToken]['code'] !== T_OPEN_TAG) {
                 return;
             }

--- a/coder_sniffer/Backdrop/Sniffs/Commenting/FileCommentSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Commenting/FileCommentSniff.php
@@ -9,9 +9,6 @@
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_CommentParser_ClassCommentParser not found');
-}
 
 /**
  * Parses and verifies the doc comments for files.
@@ -27,7 +24,17 @@ if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === f
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
 
-class Backdrop_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+//use PHP_CodeSniffer\Exceptions\RuntimeException
+
+//if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === false) {
+//    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_CommentParser_ClassCommentParser not found');
+//}
+
+class Backdrop_Sniffs_Commenting_FileCommentSniff implements Sniff
 {
 
 
@@ -52,7 +59,7 @@ class Backdrop_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sni
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // We are only interested if this is the first open tag.
         if ($stackPtr !== 0) {

--- a/coder_sniffer/Backdrop/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Commenting/FunctionCommentSniff.php
@@ -17,7 +17,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class Backdrop_Sniffs_Commenting_FunctionCommentSniff implements Sniff
 {
 
     /**
@@ -93,7 +100,7 @@ class Backdrop_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $this->currentFile = $phpcsFile;
 
@@ -121,7 +128,7 @@ class Backdrop_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer
             // The function might actually be missing a comment, and this last comment
             // found is just commenting a bit of code on a line. So if it is not the
             // only thing on the line, assume we found nothing.
-            $prevContent = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, $commentEnd);
+            $prevContent = $phpcsFile->findPrevious(Tokens::$emptyTokens, $commentEnd);
             if ($tokens[$commentEnd]['line'] === $tokens[$commentEnd]['line']) {
                 $error = 'Missing function doc comment';
                 $phpcsFile->addError($error, $stackPtr, 'Missing');
@@ -142,7 +149,7 @@ class Backdrop_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer
 
         // If there is any code between the function keyword and the doc block
         // then the doc block is not for us.
-        $ignore    = PHP_CodeSniffer_Tokens::$scopeModifiers;
+        $ignore    = Tokens::$scopeModifiers;
         $ignore[]  = T_STATIC;
         $ignore[]  = T_WHITESPACE;
         $ignore[]  = T_ABSTRACT;

--- a/coder_sniffer/Backdrop/Sniffs/Commenting/InlineCommentSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Commenting/InlineCommentSniff.php
@@ -29,7 +29,14 @@
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class Backdrop_Sniffs_Commenting_InlineCommentSniff implements Sniff
 {
 
 
@@ -57,7 +64,7 @@ class Backdrop_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_S
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -66,7 +73,7 @@ class Backdrop_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_S
         // not allowed.
         if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT) {
             $nextToken = $phpcsFile->findNext(
-                PHP_CodeSniffer_Tokens::$emptyTokens,
+                Tokens::$emptyTokens,
                 ($stackPtr + 1),
                 null,
                 true
@@ -95,7 +102,7 @@ class Backdrop_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_S
                 return;
             } else {
                 $prevToken = $phpcsFile->findPrevious(
-                    PHP_CodeSniffer_Tokens::$emptyTokens,
+                    Tokens::$emptyTokens,
                     ($stackPtr - 1),
                     null,
                     true
@@ -217,14 +224,14 @@ class Backdrop_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_S
     /**
      * Determines if a comment line is part of an @code/@endcode example.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the current token
      *                                        in the stack passed in $tokens.
      *
      * @return boolean Returns true if the comment line is within a @code block,
      *                 false otherwise.
      */
-    protected function isInCodeExample(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function isInCodeExample(File $phpcsFile, $stackPtr)
     {
         $tokens      = $phpcsFile->getTokens();
         $prevComment = $stackPtr;
@@ -253,13 +260,13 @@ class Backdrop_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_S
     /**
      * Checks the indentation level of the comment contents.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the current token
      *                                        in the stack passed in $tokens.
      *
      * @return void
      */
-    protected function processIndentation(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processIndentation(File $phpcsFile, $stackPtr)
     {
         $tokens     = $phpcsFile->getTokens();
         $comment    = rtrim($tokens[$stackPtr]['content']);

--- a/coder_sniffer/Backdrop/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -13,10 +13,6 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractPatternSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractPatternSniff not found');
-}
-
 /**
  * Verifies that control statements conform to their coding standards.
  *
@@ -29,7 +25,12 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractPatternSniff', true) === fal
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_ControlStructures_ControlSignatureSniff extends PHP_CodeSniffer_Standards_AbstractPatternSniff
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Sniffs\AbstractPatternSniff;
+
+class ControlSignatureSniff extends AbstractPatternSniff
 {
 
 

--- a/coder_sniffer/Backdrop/Sniffs/ControlStructures/ElseCatchNewlineSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/ControlStructures/ElseCatchNewlineSniff.php
@@ -19,7 +19,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_ControlStructures_ElseCatchNewlineSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ElseCatchNewlineSniff implements Sniff
 {
 
 
@@ -48,11 +55,11 @@ class Backdrop_Sniffs_ControlStructures_ElseCatchNewlineSniff implements PHP_Cod
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $prevNonWhiteSpace = $phpcsFile->findPrevious(
-            PHP_CodeSniffer_Tokens::$emptyTokens,
+            Tokens::$emptyTokens,
             ($stackPtr - 1),
             null,
             true

--- a/coder_sniffer/Backdrop/Sniffs/ControlStructures/ElseIfSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/ControlStructures/ElseIfSniff.php
@@ -13,10 +13,6 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractPatternSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractPatternSniff not found');
-}
-
 /**
  * Verifies that control statements conform to their coding standards.
  *
@@ -29,7 +25,13 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractPatternSniff', true) === fal
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_ControlStructures_ElseIfSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ElseIfSniff implements Sniff
 {
 
     /**
@@ -53,7 +55,7 @@ class Backdrop_Sniffs_ControlStructures_ElseIfSniff implements PHP_CodeSniffer_S
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
 
       $tokens = $phpcsFile->getTokens();

--- a/coder_sniffer/Backdrop/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -21,8 +21,13 @@
  * @package   PHP_CodeSniffer
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_ControlStructures_InlineControlStructureSniff
-extends Generic_Sniffs_ControlStructures_InlineControlStructureSniff
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\InlineControlStructureSniff as PHP_CodeSniffer_InlineControlStructureSniff;
+
+class InlineControlStructureSniff extends PHP_CodeSniffer_InlineControlStructureSniff
 {
 
     /**
@@ -34,7 +39,7 @@ extends Generic_Sniffs_ControlStructures_InlineControlStructureSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/coder_sniffer/Backdrop/Sniffs/ControlStructures/TemplateControlStructureSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/ControlStructures/TemplateControlStructureSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_ControlStructures_TemplateControlStructureSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class TemplateControlStructureSniff implements Sniff
 {
 
 
@@ -50,7 +56,7 @@ class Backdrop_Sniffs_ControlStructures_TemplateControlStructureSniff implements
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // Only process this sniff for template files.
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -8));

--- a/coder_sniffer/Backdrop/Sniffs/Files/LineLengthSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Files/LineLengthSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Files_LineLengthSniff extends Generic_Sniffs_Files_LineLengthSniff
+
+namespace Backdrop\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff as PHP_CodeSniffer_LineLengthSniff;
+
+class LineLengthSniff extends PHP_CodeSniffer_LineLengthSniff
 {
 
     /**
@@ -37,34 +43,42 @@ class Backdrop_Sniffs_Files_LineLengthSniff extends Generic_Sniffs_Files_LineLen
      */
     public $absoluteLineLimit = 0;
 
-
-    /**
-     * Checks if a line is too long.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
-     * @param int                  $stackPtr    The token at the end of the line.
-     * @param string               $lineContent The content of the line.
-     *
-     * @return void
-     */
-    protected function checkLineLength(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $lineContent)
-    {
-        $tokens = $phpcsFile->getTokens();
-        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT || $tokens[$stackPtr]['code'] === T_COMMENT) {
-            if (preg_match('/^[[:space:]]*(\/\*)?\*[[:space:]]*@link.*@endlink[[:space:]]*/', $lineContent) === 1) {
-                // Allow @link documentation to exceed the 80 character limit.
-                return;
-            }
-
-            if (preg_match('/^[[:space:]]*((\/\*)?\*|\/\/)[[:space:]]*@see.*/', $lineContent) === 1) {
-                // Allow @see documentation to exceed the 80 character limit.
-                return;
-            }
-
-            parent::checkLineLength($phpcsFile, $stackPtr, $lineContent);
-        }
-
-    }//end checkLineLength()
+//
+//    /**
+//     * Checks if a line is too long.
+//     *
+//     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+//     * @param int                  $stackPtr    The token at the end of the line.
+//     * @param string               $lineContent The content of the line.
+//     *
+//     * @return void
+//     */
+//    protected function checkLineLength($phpcsFile, $tokens, $stackPtr)
+//    {
+////        $backtrace = debug_backtrace();
+////        foreach ($backtrace as $key => $value) {
+////          print_r($value['file'] . "\n");
+////          print_r($value['line'] . "\n");
+////          print_r($value['function'] . "\n");
+////          print_r("\n");
+////        }
+//
+//
+//        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT || $tokens[$stackPtr]['code'] === T_COMMENT) {
+//            if (preg_match('/^[[:space:]]*(\/\*)?\*[[:space:]]*@link.*@endlink[[:space:]]*/', $lineContent) === 1) {
+//                // Allow @link documentation to exceed the 80 character limit.
+//                return;
+//            }
+//
+//            if (preg_match('/^[[:space:]]*((\/\*)?\*|\/\/)[[:space:]]*@see.*/', $lineContent) === 1) {
+//                // Allow @see documentation to exceed the 80 character limit.
+//                return;
+//            }
+//
+//            parent::checkLineLength($phpcsFile, $tokens, $stackPtr);
+//        }
+//
+//    }//end checkLineLength()
 
 
     /**
@@ -72,7 +86,7 @@ class Backdrop_Sniffs_Files_LineLengthSniff extends Generic_Sniffs_Files_LineLen
      *
      * @return integer
      */
-    public function getLineLength(PHP_CodeSniffer_File $phpcsFile, $currentLine)
+    public function getLineLength(File $phpcsFile, $currentLine)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -92,5 +106,3 @@ class Backdrop_Sniffs_Files_LineLengthSniff extends Generic_Sniffs_Files_LineLen
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/Files/LineLengthSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Files/LineLengthSniff.php
@@ -43,42 +43,52 @@ class LineLengthSniff extends PHP_CodeSniffer_LineLengthSniff
      */
     public $absoluteLineLimit = 0;
 
-//
-//    /**
-//     * Checks if a line is too long.
-//     *
-//     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
-//     * @param int                  $stackPtr    The token at the end of the line.
-//     * @param string               $lineContent The content of the line.
-//     *
-//     * @return void
-//     */
-//    protected function checkLineLength($phpcsFile, $tokens, $stackPtr)
-//    {
-////        $backtrace = debug_backtrace();
-////        foreach ($backtrace as $key => $value) {
-////          print_r($value['file'] . "\n");
-////          print_r($value['line'] . "\n");
-////          print_r($value['function'] . "\n");
-////          print_r("\n");
-////        }
-//
-//
-//        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT || $tokens[$stackPtr]['code'] === T_COMMENT) {
-//            if (preg_match('/^[[:space:]]*(\/\*)?\*[[:space:]]*@link.*@endlink[[:space:]]*/', $lineContent) === 1) {
-//                // Allow @link documentation to exceed the 80 character limit.
-//                return;
-//            }
-//
-//            if (preg_match('/^[[:space:]]*((\/\*)?\*|\/\/)[[:space:]]*@see.*/', $lineContent) === 1) {
-//                // Allow @see documentation to exceed the 80 character limit.
-//                return;
-//            }
-//
-//            parent::checkLineLength($phpcsFile, $tokens, $stackPtr);
-//        }
-//
-//    }//end checkLineLength()
+    /**
+     * Variable to store the code from each line of the file so that the
+     * complete line can be checked with regular expressions.
+     *
+     * @var array
+     */
+    public $code = array();
+
+    /**
+     * Checks if a line is too long.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                  $stackPtr    The token at the end of the line.
+     * @param string               $lineContent The content of the line.
+     *
+     * @return void
+     */
+    protected function checkLineLength($phpcsFile, $tokens, $stackPtr)
+    {
+
+      if (empty($this->code)) {
+        foreach ($tokens as $token) {
+          if (isset($this->code[$token['line']])) {
+            $this->code[$token['line']] .= $token['content'];
+          }
+          else {
+            $this->code[$token['line']] = $token['content'];
+          }
+        }
+      }
+
+      if (isset($tokens[$stackPtr])) {
+          if (preg_match('/^[[:space:]]*(\/\*)?\*[[:space:]]*@link.*@endlink[[:space:]]*/', $this->code[$tokens[$stackPtr]['line']]) === 1) {
+              // Allow @link documentation to exceed the 80 character limit.
+              return;
+          }
+
+          if (preg_match('/^[[:space:]]*((\/\*)?\*|\/\/)[[:space:]]*@see.*/', $this->code[$tokens[$stackPtr]['line']]) === 1) {
+              // Allow @see documentation to exceed the 80 character limit.
+              return;
+          }
+
+          parent::checkLineLength($phpcsFile, $tokens, $stackPtr);
+      }
+
+    }//end checkLineLength()
 
 
     /**

--- a/coder_sniffer/Backdrop/Sniffs/Files/TxtFileLineLengthSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Files/TxtFileLineLengthSniff.php
@@ -21,7 +21,13 @@
  * @author   Klaus Purer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Files_TxtFileLineLengthSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Files;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class TxtFileLineLengthSniff implements Sniff
 {
 
 
@@ -46,7 +52,7 @@ class Backdrop_Sniffs_Files_TxtFileLineLengthSniff implements PHP_CodeSniffer_Sn
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -3));
         if ($fileExtension === 'txt' || $fileExtension === '.md') {

--- a/coder_sniffer/Backdrop/Sniffs/Formatting/DisallowCloseTagSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Formatting/DisallowCloseTagSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Formatting_DisallowCloseTagSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class DisallowCloseTagSniff implements Sniff
 {
 
 
@@ -41,11 +48,11 @@ class Backdrop_Sniffs_Formatting_DisallowCloseTagSniff implements PHP_CodeSniffe
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if ($next === false) {
             $error = 'The final ?> should be omitted from all code files';
             $phpcsFile->addError($error, $stackPtr, 'FinalClose');

--- a/coder_sniffer/Backdrop/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -25,7 +25,13 @@
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class MultiLineAssignmentSniff implements Sniff
 {
 
 
@@ -50,7 +56,7 @@ class Backdrop_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSni
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -63,7 +69,7 @@ class Backdrop_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSni
 
         if ($tokens[$next]['line'] !== $tokens[$stackPtr]['line']) {
             $error = 'Multi-line assignments must have the equal sign on the second line';
-            $phpcsFile->addError($error, $stackPtr);
+            $phpcsFile->addError($error, $stackPtr, 'MultiLineAssignment');
             return;
         }
 
@@ -99,7 +105,7 @@ class Backdrop_Sniffs_Formatting_MultiLineAssignmentSniff implements PHP_CodeSni
         $foundIndent    = strlen($tokens[$prev]['content']);
         if ($foundIndent !== $expectedIndent) {
             $error = "Multi-line assignment not indented correctly; expected $expectedIndent spaces but found $foundIndent";
-            $phpcsFile->addError($error, $stackPtr);
+            $phpcsFile->addError($error, $stackPtr, 'MultiLineAssignment');
         }
 
     }//end process()

--- a/coder_sniffer/Backdrop/Sniffs/Formatting/SpaceInlineIfSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Formatting/SpaceInlineIfSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Formatting_SpaceInlineIfSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff;
+
+class SpaceInlineIfSniff implements Sniff
 {
 
 
@@ -44,7 +51,7 @@ class Backdrop_Sniffs_Formatting_SpaceInlineIfSniff implements PHP_CodeSniffer_S
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens   = $phpcsFile->getTokens();
         $operator = $tokens[$stackPtr]['content'];
@@ -92,12 +99,10 @@ class Backdrop_Sniffs_Formatting_SpaceInlineIfSniff implements PHP_CodeSniffer_S
         }
 
         // Reuse the standard operator sniff now.
-        $sniff = new Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff();
+        $sniff = new OperatorSpacingSniff();
         $sniff->process($phpcsFile, $stackPtr);
 
     }//end process()
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/Formatting/SpaceUnaryOperatorSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Formatting/SpaceUnaryOperatorSniff.php
@@ -19,7 +19,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Formatting_SpaceUnaryOperatorSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class SpaceUnaryOperatorSniff implements Sniff
 {
 
 
@@ -50,7 +56,7 @@ class Backdrop_Sniffs_Formatting_SpaceUnaryOperatorSniff implements PHP_CodeSnif
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/coder_sniffer/Backdrop/Sniffs/Functions/DiscouragedFunctionsSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Functions/DiscouragedFunctionsSniff.php
@@ -16,7 +16,12 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Functions_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff
+
+namespace Backdrop\Sniffs\Functions;
+
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
+
+class DiscouragedFunctionsSniff extends ForbiddenFunctionsSniff
 {
 
     /**
@@ -27,7 +32,7 @@ class Backdrop_Sniffs_Functions_DiscouragedFunctionsSniff extends Generic_Sniffs
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                      // Devel module debugging functions.
                                      'dargs'               => null,
                                      'dcp'                 => null,
@@ -56,5 +61,3 @@ class Backdrop_Sniffs_Functions_DiscouragedFunctionsSniff extends Generic_Sniffs
     public $error = false;
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Functions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class FunctionDeclarationSniff implements Sniff
 {
 
 
@@ -42,7 +48,7 @@ class Backdrop_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSnif
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -62,5 +68,3 @@ class Backdrop_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSnif
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/InfoFiles/ClassFilesSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/InfoFiles/ClassFilesSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_InfoFiles_ClassFilesSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\InfoFiles;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassFilesSniff implements Sniff
 {
 
 
@@ -42,7 +48,7 @@ class Backdrop_Sniffs_InfoFiles_ClassFilesSniff implements PHP_CodeSniffer_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -4));
         if ($fileExtension !== 'info') {
@@ -96,7 +102,7 @@ class Backdrop_Sniffs_InfoFiles_ClassFilesSniff implements PHP_CodeSniffer_Sniff
      * @return int|false Returns the stack position if the file name is found, false
      * 									 otherwise.
      */
-    public static function getPtr($key, $value, PHP_CodeSniffer_File $infoFile)
+    public static function getPtr($key, $value, File $infoFile)
     {
         foreach ($infoFile->getTokens() as $ptr => $tokenInfo) {
             if (preg_match('@^[\s]*'.preg_quote($key).'[\s]*=[\s]*["\']?'.preg_quote($value).'["\']?@', $tokenInfo['content']) === 1) {
@@ -177,5 +183,3 @@ class Backdrop_Sniffs_InfoFiles_ClassFilesSniff implements PHP_CodeSniffer_Sniff
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/InfoFiles/RequiredSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/InfoFiles/RequiredSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_InfoFiles_RequiredSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\InfoFiles;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class RequiredSniff implements Sniff
 {
 
 
@@ -42,7 +48,7 @@ class Backdrop_Sniffs_InfoFiles_RequiredSniff implements PHP_CodeSniffer_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -4));
         if ($fileExtension !== 'info') {
@@ -82,5 +88,3 @@ class Backdrop_Sniffs_InfoFiles_RequiredSniff implements PHP_CodeSniffer_Sniff
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/NamingConventions/KeywordLowerCaseSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/NamingConventions/KeywordLowerCaseSniff.php
@@ -16,7 +16,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_NamingConventions_KeywordLowerCaseSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class KeywordLowerCaseSniff implements Sniff
 {
 
 
@@ -41,7 +47,7 @@ class Backdrop_Sniffs_NamingConventions_KeywordLowerCaseSniff implements PHP_Cod
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         if ($tokens[$stackPtr]['content'] !== strtolower($tokens[$stackPtr]['content'])) {

--- a/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -28,7 +28,13 @@
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ValidClassNameSniff implements Sniff
 {
 
 
@@ -56,7 +62,7 @@ class Backdrop_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -80,6 +86,3 @@ class Backdrop_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
 
 
 }//end class
-
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -14,10 +14,6 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractScopeSniff not found');
-}
-
 /**
  * Backdrop_Sniffs_NamingConventions_ValidFunctionNameSniff.
  *
@@ -34,7 +30,13 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidVariableNameSniff as PEAR_ValidFunctionNameSniff;
+
+class ValidFunctionNameSniff extends PEAR_ValidFunctionNameSniff
 {
 
     /**
@@ -47,48 +49,48 @@ class Backdrop_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Snif
      *
      * @return void
      */
-    protected function processTokenWithinScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
-    {
-        $methodName = $phpcsFile->getDeclarationName($stackPtr);
-        if ($methodName === null) {
-            // Ignore closures.
-            return;
-        }
-
-        $className = $phpcsFile->getDeclarationName($currScope);
-        $errorData = array($className.'::'.$methodName);
-
-        // Is this a magic method. i.e., is prefixed with "__" ?
-        if (preg_match('|^__|', $methodName) !== 0) {
-            $magicPart = strtolower(substr($methodName, 2));
-            if (in_array($magicPart, $this->magicMethods) === false) {
-                 $error = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
-                 $phpcsFile->addError($error, $stackPtr, 'MethodDoubleUnderscore', $errorData);
-            }
-
-            return;
-        }
-
-        $methodProps    = $phpcsFile->getMethodProperties($stackPtr);
-        $scope          = $methodProps['scope'];
-        $scopeSpecified = $methodProps['scope_specified'];
-
-        // Methods should not contain underscores.
-        if (strpos($methodName, '_') !== false) {
-          if ($scopeSpecified === true) {
-              $error = '%s method name "%s" is not in lowerCamel format, it must not contain underscores';
-              $data  = array(
-              ucfirst($scope),
-              $errorData[0],
-              );
-              $phpcsFile->addError($error, $stackPtr, 'ScopeNotLowerCamel', $data);
-          } else {
-              $error = 'Method name "%s" is not in lowerCamel format, it must not contain underscores';
-              $phpcsFile->addError($error, $stackPtr, 'NotLowerCamel', $errorData);
-          }
-        }
-
-    }//end processTokenWithinScope()
+//    protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
+//    {
+//        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+//        if ($methodName === null) {
+//            // Ignore closures.
+//            return;
+//        }
+//
+//        $className = $phpcsFile->getDeclarationName($currScope);
+//        $errorData = array($className.'::'.$methodName);
+//
+//        // Is this a magic method. i.e., is prefixed with "__" ?
+//        if (preg_match('|^__|', $methodName) !== 0) {
+//            $magicPart = strtolower(substr($methodName, 2));
+//            if (in_array($magicPart, $this->magicMethods) === false) {
+//                 $error = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
+//                 $phpcsFile->addError($error, $stackPtr, 'MethodDoubleUnderscore', $errorData);
+//            }
+//
+//            return;
+//        }
+//
+//        $methodProps    = $phpcsFile->getMethodProperties($stackPtr);
+//        $scope          = $methodProps['scope'];
+//        $scopeSpecified = $methodProps['scope_specified'];
+//
+//        // Methods should not contain underscores.
+//        if (strpos($methodName, '_') !== false) {
+//          if ($scopeSpecified === true) {
+//              $error = '%s method name "%s" is not in lowerCamel format, it must not contain underscores';
+//              $data  = array(
+//              ucfirst($scope),
+//              $errorData[0],
+//              );
+//              $phpcsFile->addError($error, $stackPtr, 'ScopeNotLowerCamel', $data);
+//          } else {
+//              $error = 'Method name "%s" is not in lowerCamel format, it must not contain underscores';
+//              $phpcsFile->addError($error, $stackPtr, 'NotLowerCamel', $errorData);
+//          }
+//        }
+//
+//    }//end processTokenWithinScope()
 
 
     /**
@@ -100,11 +102,11 @@ class Backdrop_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Snif
      *
      * @return void
      */
-    protected function processTokenOutsideScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        // Empty override, does not apply to Backdrop.
-
-    }//end processTokenOutsideScope()
+//    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
+//    {
+//        // Empty override, does not apply to Backdrop.
+//
+//    }//end processTokenOutsideScope()
 
 
 }//end class

--- a/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidGlobalSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidGlobalSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_NamingConventions_ValidGlobalSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ValidGlobalSniff implements Sniff
 {
 
     public $coreGlobals = array(
@@ -90,13 +97,13 @@ class Backdrop_Sniffs_NamingConventions_ValidGlobalSniff implements PHP_CodeSnif
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         $varToken = $stackPtr;
         // Find variable names until we hit a semicolon.
-        $ignore   = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $ignore   = Tokens::$emptyTokens;
         $ignore[] = T_SEMICOLON;
         while ($varToken = $phpcsFile->findNext($ignore, $varToken + 1, null, true, null, true)) {
             if ($tokens[$varToken]['code'] === T_VARIABLE
@@ -112,5 +119,3 @@ class Backdrop_Sniffs_NamingConventions_ValidGlobalSniff implements PHP_CodeSnif
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -18,9 +18,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_NamingConventions_ValidVariableNameSniff
 
-    extends PHP_CodeSniffer_Standards_AbstractVariableSniff
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+
+class ValidVariableNameSniff extends AbstractVariableSniff
 {
 
 
@@ -33,7 +37,7 @@ class Backdrop_Sniffs_NamingConventions_ValidVariableNameSniff
      *
      * @return void
      */
-    protected function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processMemberVar(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -61,7 +65,7 @@ class Backdrop_Sniffs_NamingConventions_ValidVariableNameSniff
      *
      * @return void
      */
-    protected function processVariable(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processVariable(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -91,7 +95,7 @@ class Backdrop_Sniffs_NamingConventions_ValidVariableNameSniff
 
         if (preg_match('/[A-Z]/', $varName)) {
             $error = "Variable \"$varName\" is camel caps format. do not use mixed case (camelCase), use lower case and _";
-            $phpcsFile->addError($error, $stackPtr);
+            $phpcsFile->addError($error, $stackPtr, 'CamelCase');
         }
 
     }//end processVariable()
@@ -105,7 +109,7 @@ class Backdrop_Sniffs_NamingConventions_ValidVariableNameSniff
      *
      * @return void
      */
-    protected function processVariableInString(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processVariableInString(File $phpcsFile, $stackPtr)
     {
         // We don't care about variables in strings.
 

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/ConstantNameSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/ConstantNameSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_ConstantNameSniff extends Backdrop_Sniffs_Semantics_FunctionCall
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use Backdrop\Sniffs\Semantics\FunctionCall;
+use Backdrop\Sniffs\Semantics\FunctionCallSnif;
+
+class ConstantNameSniff extends FunctionCall
 {
 
 
@@ -51,11 +57,11 @@ class Backdrop_Sniffs_Semantics_ConstantNameSniff extends Backdrop_Sniffs_Semant
      * @return void
      */
     public function processFunctionCall(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $openBracket,
         $closeBracket,
-        Backdrop_Sniffs_Semantics_FunctionCallSniff $sniff
+        FunctionCallSniff $sniff
     ) {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -6));
         // Only check in *.module files.

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/EmptyInstallSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/EmptyInstallSniff.php
@@ -16,7 +16,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_EmptyInstallSniff extends Backdrop_Sniffs_Semantics_FunctionDefinition
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use Backdrop\Sniffs\Semantics\FunctionDefinition;
+
+class EmptyInstallSniff extends FunctionDefinition
 {
 
 
@@ -31,7 +37,7 @@ class Backdrop_Sniffs_Semantics_EmptyInstallSniff extends Backdrop_Sniffs_Semant
      *
      * @return void
      */
-    public function processFunction(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionPtr)
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -7));
         // Only check in *.install files.
@@ -46,7 +52,7 @@ class Backdrop_Sniffs_Semantics_EmptyInstallSniff extends Backdrop_Sniffs_Semant
         ) {
             // Check if there is a function body.
             $bodyPtr = $phpcsFile->findNext(
-                PHP_CodeSniffer_Tokens::$emptyTokens,
+                Tokens::$emptyTokens,
                 ($tokens[$functionPtr]['scope_opener'] + 1),
                 $tokens[$functionPtr]['scope_closer'],
                 true

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionAliasSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionAliasSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_FunctionAliasSniff extends Backdrop_Sniffs_Semantics_FunctionCall
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use Backdrop\Sniffs\Semantics\FunctionCall;
+use Backdrop\Sniffs\Semantics\FunctionCallSniff;
+
+class FunctionAliasSniff extends FunctionCall
 {
 
     /**
@@ -331,11 +338,11 @@ class Backdrop_Sniffs_Semantics_FunctionAliasSniff extends Backdrop_Sniffs_Seman
      * @return void
      */
     public function processFunctionCall(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $openBracket,
         $closeBracket,
-        Backdrop_Sniffs_Semantics_FunctionCallSniff $sniff
+        FunctionCallSniff $sniff
     ) {
         $tokens = $phpcsFile->getTokens();
         $error  = '%s() is a function name alias, use %s() instead';

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionCall.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionCall.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-abstract class Backdrop_Sniffs_Semantics_FunctionCall implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use Backdrop\Sniffs\Semantics\FunctionCallSniff;
+
+abstract class FunctionCall implements Sniff
 {
 
 
@@ -28,7 +35,7 @@ abstract class Backdrop_Sniffs_Semantics_FunctionCall implements PHP_CodeSniffer
     public function register()
     {
         // We do not listen for tokens, but for specific function calls.
-        Backdrop_Sniffs_Semantics_FunctionCallSniff::registerListener($this);
+        FunctionCallSniff::registerListener($this);
         return array();
 
     }//end register()
@@ -43,7 +50,7 @@ abstract class Backdrop_Sniffs_Semantics_FunctionCall implements PHP_CodeSniffer
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // Empty default implementation, because processFunctionCall() is used.
 
@@ -68,11 +75,11 @@ abstract class Backdrop_Sniffs_Semantics_FunctionCall implements PHP_CodeSniffer
      * @return void
      */
     public abstract function processFunctionCall(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $openBracket,
         $closeBracket,
-        Backdrop_Sniffs_Semantics_FunctionCallSniff $sniff
+        FunctionCallSniff $sniff
     );
 
 

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionCallSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionCallSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class FunctionCallSniff implements Sniff
 {
 
     /**
@@ -84,7 +91,7 @@ class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sni
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens       = $phpcsFile->getTokens();
         $functionName = $tokens[$stackPtr]['content'];
@@ -98,7 +105,7 @@ class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sni
         }
 
         // Find the next non-empty token.
-        $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         $this->phpcsFile    = $phpcsFile;
         $this->functionCall = $stackPtr;
@@ -122,11 +129,11 @@ class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sni
      *
      * @return bool
      */
-    protected function isFunctionCall(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function isFunctionCall(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         // Find the next non-empty token.
-        $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
             // Not a function call.
@@ -139,7 +146,7 @@ class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sni
         }
 
         // Find the previous non-empty token.
-        $search   = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $search   = Tokens::$emptyTokens;
         $search[] = T_BITWISE_AND;
         $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
         if ($tokens[$previous]['code'] === T_FUNCTION) {
@@ -179,14 +186,14 @@ class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sni
 
         $tokens = $this->phpcsFile->getTokens();
         // Start token of the first argument.
-        $start = $this->phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($this->openBracket + 1), null, true);
+        $start = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($this->openBracket + 1), null, true);
         if ($start === $this->closeBracket) {
             // Function call has no arguments, so return false.
             return false;
         }
 
         // End token of the last argument.
-        $end = $this->phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($this->closeBracket - 1), null, true);
+        $end = $this->phpcsFile->findPrevious(Tokens::$emptyTokens, ($this->closeBracket - 1), null, true);
         $lastArgEnd    = $end;
         $nextSeperator = $this->openBracket;
         $counter       = 1;
@@ -200,7 +207,7 @@ class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sni
             }
 
             // Update the end token of the current argument.
-            $end = $this->phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextSeperator - 1), null, true);
+            $end = $this->phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextSeperator - 1), null, true);
             // Save the calculated findings for the current argument.
             $this->arguments[$counter] = array(
                                           'start' => $start,
@@ -211,7 +218,7 @@ class Backdrop_Sniffs_Semantics_FunctionCallSniff implements PHP_CodeSniffer_Sni
             }
 
             $counter++;
-            $start = $this->phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextSeperator + 1), null, true);
+            $start = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($nextSeperator + 1), null, true);
             $end   = $lastArgEnd;
         }//end while
 

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionDefinition.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionDefinition.php
@@ -16,7 +16,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-abstract class Backdrop_Sniffs_Semantics_FunctionDefinition implements PHP_CodeSniffer_Sniff
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+abstract class FunctionDefinition implements Sniff
 {
 
 
@@ -41,12 +47,12 @@ abstract class Backdrop_Sniffs_Semantics_FunctionDefinition implements PHP_CodeS
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         // Check if this is a function definition.
         $functionPtr = $phpcsFile->findPrevious(
-            PHP_CodeSniffer_Tokens::$emptyTokens,
+            Tokens::$emptyTokens,
             ($stackPtr - 1),
             null,
             true
@@ -69,7 +75,7 @@ abstract class Backdrop_Sniffs_Semantics_FunctionDefinition implements PHP_CodeS
      *
      * @return void
      */
-    public abstract function processFunction(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionPtr);
+    public abstract function processFunction(File $phpcsFile, $stackPtr, $functionPtr);
 
 
 }//end class

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionTSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionTSniff.php
@@ -17,7 +17,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_FunctionTSniff extends Backdrop_Sniffs_Semantics_FunctionCall
+
+namespace Backdrop\Sniffs\Semantics;
+
+use Backdrop\Sniffs\Semantics\FunctionCall;
+use Backdrop\Sniffs\Semantics\FunctionCallSniff;
+use PHP_CodeSniffer\Files\File;
+
+class FunctionTSniff extends FunctionCall
 {
 
 
@@ -51,11 +58,11 @@ class Backdrop_Sniffs_Semantics_FunctionTSniff extends Backdrop_Sniffs_Semantics
      * @return void
      */
     public function processFunctionCall(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $openBracket,
         $closeBracket,
-        Backdrop_Sniffs_Semantics_FunctionCallSniff $sniff
+        FunctionCallSniff $sniff
     ) {
         $tokens   = $phpcsFile->getTokens();
         $argument = $sniff->getArgument(1);

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionWatchdogSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/FunctionWatchdogSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_FunctionWatchdogSniff extends Backdrop_Sniffs_Semantics_FunctionCall
+
+namespace Backdrop\Sniffs\Semantics;
+
+use Backdrop\Sniffs\Semantics\FunctionCall;
+use Backdrop\Sniffs\Semantics\FunctionCallSniff;
+use PHP_CodeSniffer\Files\File;
+
+class FunctionWatchdogSniff extends FunctionCall
 {
 
 
@@ -50,11 +57,11 @@ class Backdrop_Sniffs_Semantics_FunctionWatchdogSniff extends Backdrop_Sniffs_Se
      * @return void
      */
     public function processFunctionCall(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $openBracket,
         $closeBracket,
-        Backdrop_Sniffs_Semantics_FunctionCallSniff $sniff
+        FunctionCallSniff $sniff
     ) {
         $tokens = $phpcsFile->getTokens();
         // Get the second argument passed to watchdog().

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/InstallHooksSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/InstallHooksSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_InstallHooksSniff extends Backdrop_Sniffs_Semantics_FunctionDefinition
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use Backdrop\Sniffs\Semantics\FunctionDefinition;
+
+class InstallHooksSniff extends FunctionDefinition
 {
 
 
@@ -32,7 +38,7 @@ class Backdrop_Sniffs_Semantics_InstallHooksSniff extends Backdrop_Sniffs_Semant
      *
      * @return void
      */
-    public function processFunction(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionPtr)
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -6));
         // Only check in *.module files.

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/InstallTSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/InstallTSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_InstallTSniff extends Backdrop_Sniffs_Semantics_FunctionDefinition
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use Backdrop\Sniffs\Semantics\FunctionDefinition;
+
+class InstallTSniff extends FunctionDefinition
 {
 
 
@@ -31,7 +38,7 @@ class Backdrop_Sniffs_Semantics_InstallTSniff extends Backdrop_Sniffs_Semantics_
      *
      * @return void
      */
-    public function processFunction(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionPtr)
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -7));
         // Only check in *.install files.
@@ -56,7 +63,7 @@ class Backdrop_Sniffs_Semantics_InstallTSniff extends Backdrop_Sniffs_Semantics_
         while ($string !== false) {
             if ($tokens[$string]['content'] === 't' || $tokens[$string]['content'] === 'st') {
                 $opener = $phpcsFile->findNext(
-                    PHP_CodeSniffer_Tokens::$emptyTokens,
+                    Tokens::$emptyTokens,
                     ($string + 1),
                     null,
                     true

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/LStringTranslatableSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/LStringTranslatableSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_LStringTranslatableSniff extends Backdrop_Sniffs_Semantics_FunctionCall
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use Backdrop\Sniffs\Semantics\FunctionCall;
+use Backdrop\Sniffs\Semantics\FunctionCallSniff;
+
+class LStringTranslatableSniff extends FunctionCall
 {
 
 
@@ -50,11 +57,11 @@ class Backdrop_Sniffs_Semantics_LStringTranslatableSniff extends Backdrop_Sniffs
      * @return void
      */
     public function processFunctionCall(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $openBracket,
         $closeBracket,
-        Backdrop_Sniffs_Semantics_FunctionCallSniff $sniff
+        FunctionCallSniff $sniff
     ) {
         $tokens = $phpcsFile->getTokens();
         // Get the first argument passed to l().

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/PregSecuritySniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/PregSecuritySniff.php
@@ -17,7 +17,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_PregSecuritySniff extends Backdrop_Sniffs_Semantics_FunctionCall
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use Backdrop\Sniffs\Semantics\FunctionCall;
+use Backdrop\Sniffs\Semantics\FunctionCallSniff;
+
+class PregSecuritySniff extends FunctionCall
 {
 
 
@@ -59,11 +66,11 @@ class Backdrop_Sniffs_Semantics_PregSecuritySniff extends Backdrop_Sniffs_Semant
      * @return void
      */
     public function processFunctionCall(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $openBracket,
         $closeBracket,
-        Backdrop_Sniffs_Semantics_FunctionCallSniff $sniff
+        FunctionCallSniff $sniff
     ) {
         $tokens   = $phpcsFile->getTokens();
         $argument = $sniff->getArgument(1);

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/RemoteAddressSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/RemoteAddressSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_RemoteAddressSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class RemoteAddressSniff implements Sniff
 {
 
 
@@ -42,7 +48,7 @@ class Backdrop_Sniffs_Semantics_RemoteAddressSniff implements PHP_CodeSniffer_Sn
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $string = $phpcsFile->getTokensAsString($stackPtr, 4);
         if ($string === '$_SERVER["REMOTE_ADDR"]' || $string === '$_SERVER[\'REMOTE_ADDR\']') {

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/TInHookMenuSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/TInHookMenuSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_TInHookMenuSniff extends Backdrop_Sniffs_Semantics_FunctionDefinition
+
+namespace Backdrop\Sniffs\Semantics;
+
+use Backdrop\Sniffs\Semantics\FunctionDefinition;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class TInHookMenuSniff extends FunctionDefinition
 {
 
 
@@ -31,7 +38,7 @@ class Backdrop_Sniffs_Semantics_TInHookMenuSniff extends Backdrop_Sniffs_Semanti
      *
      * @return void
      */
-    public function processFunction(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionPtr)
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -6));
         // Only check in *.module files.
@@ -54,7 +61,7 @@ class Backdrop_Sniffs_Semantics_TInHookMenuSniff extends Backdrop_Sniffs_Semanti
         while ($string !== false) {
             if ($tokens[$string]['content'] === 't') {
                 $opener = $phpcsFile->findNext(
-                    PHP_CodeSniffer_Tokens::$emptyTokens,
+                    Tokens::$emptyTokens,
                     ($string + 1),
                     null,
                     true

--- a/coder_sniffer/Backdrop/Sniffs/Semantics/TInHookSchemaSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Semantics/TInHookSchemaSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Semantics_TInHookSchemaSniff extends Backdrop_Sniffs_Semantics_FunctionDefinition
+
+namespace Backdrop\Sniffs\Semantics;
+
+use Backdrop\Sniffs\Semantics\FunctionDefinition;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class TInHookSchemaSniff extends FunctionDefinition
 {
 
 
@@ -31,7 +38,7 @@ class Backdrop_Sniffs_Semantics_TInHookSchemaSniff extends Backdrop_Sniffs_Seman
      *
      * @return void
      */
-    public function processFunction(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionPtr)
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
     {
         $fileExtension = strtolower(substr($phpcsFile->getFilename(), -7));
         // Only check in *.install files.
@@ -54,7 +61,7 @@ class Backdrop_Sniffs_Semantics_TInHookSchemaSniff extends Backdrop_Sniffs_Seman
         while ($string !== false) {
             if ($tokens[$string]['content'] === 't') {
                 $opener = $phpcsFile->findNext(
-                    PHP_CodeSniffer_Tokens::$emptyTokens,
+                    Tokens::$emptyTokens,
                     ($string + 1),
                     null,
                     true

--- a/coder_sniffer/Backdrop/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -21,7 +21,13 @@
  * @author    Peter Philipp <peter.philipp@cando-image.com>
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Strings_ConcatenationSpacingSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\Strings;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class Backdrop_Sniffs_Strings_ConcatenationSpacingSniff implements Sniff
 {
 
 
@@ -40,7 +46,7 @@ class Backdrop_Sniffs_Strings_ConcatenationSpacingSniff implements PHP_CodeSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE || $tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
@@ -49,5 +55,3 @@ class Backdrop_Sniffs_Strings_ConcatenationSpacingSniff implements PHP_CodeSniff
         }
     }
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -27,7 +27,15 @@
  * @version   Release: 1.3.1
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_Strings_UnnecessaryStringConcatSniff extends Generic_Sniffs_Strings_UnnecessaryStringConcatSniff
+
+namespace Backdrop\Sniffs\Strings;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Strings\UnnecessaryStringConcatSniff as PHP_CodeSniffer_UnnecessaryStringConcatSniff;
+use Backdrop\Sniffs\Files\LineLengthSniff;
+
+class UnnecessaryStringConcatSniff extends PHP_CodeSniffer_UnnecessaryStringConcatSniff
 {
 
 
@@ -40,7 +48,7 @@ class Backdrop_Sniffs_Strings_UnnecessaryStringConcatSniff extends Generic_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // Work out which type of file this is for.
         $tokens = $phpcsFile->getTokens();
@@ -60,7 +68,7 @@ class Backdrop_Sniffs_Strings_UnnecessaryStringConcatSniff extends Generic_Sniff
             return;
         }
 
-        $stringTokens = PHP_CodeSniffer_Tokens::$stringTokens;
+        $stringTokens = Tokens::$stringTokens;
         if (in_array($tokens[$prev]['code'], $stringTokens) === true
             && in_array($tokens[$next]['code'], $stringTokens) === true
         ) {
@@ -79,7 +87,7 @@ class Backdrop_Sniffs_Strings_UnnecessaryStringConcatSniff extends Generic_Sniff
 
                 // Before we throw an error check if the string is longer than
                 // the line length limit.
-                $lineLengthLimitSniff = new Backdrop_Sniffs_Files_LineLengthSniff;
+                $lineLengthLimitSniff = new LineLengthSniff();
 
                 $lineLenght = $lineLengthLimitSniff->getLineLength($phpcsFile, $tokens[$prev]['line']);
                 $stringLength = ($lineLenght + strlen($tokens[$next]['content']) - 4);

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/CloseBracketSpacingSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/CloseBracketSpacingSniff.php
@@ -17,7 +17,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_CloseBracketSpacingSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class CloseBracketSpacingSniff implements Sniff
 {
 
     /**
@@ -55,7 +62,7 @@ class Backdrop_Sniffs_WhiteSpace_CloseBracketSpacingSniff implements PHP_CodeSni
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -69,7 +76,7 @@ class Backdrop_Sniffs_WhiteSpace_CloseBracketSpacingSniff implements PHP_CodeSni
         if (isset($tokens[($stackPtr - 1)]) === true
             && $tokens[($stackPtr - 1)]['code'] === T_WHITESPACE
         ) {
-            $before = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $before = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if ($before !== false && $tokens[$stackPtr]['line'] === $tokens[$before]['line']) {
                 $error = 'There should be no white space before a closing "%s"';
                 $phpcsFile->addError(

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/EmptyLinesSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/EmptyLinesSniff.php
@@ -20,7 +20,13 @@
  * @author   Klaus Purer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_EmptyLinesSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class EmptyLinesSniff implements Sniff
 {
 
     /**
@@ -56,7 +62,7 @@ class Backdrop_Sniffs_WhiteSpace_EmptyLinesSniff implements PHP_CodeSniffer_Snif
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         if ($tokens[$stackPtr]['content'] === $phpcsFile->eolChar

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/FileEndSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/FileEndSniff.php
@@ -20,7 +20,13 @@
  * @author   Klaus Purer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_FileEndSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class FileEndSniff implements Sniff
 {
 
     /**
@@ -59,7 +65,7 @@ class Backdrop_Sniffs_WhiteSpace_FileEndSniff implements PHP_CodeSniffer_Sniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // We want to run this method only once per file, so we remember if this has
         // been called already.

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -26,7 +26,13 @@
  * @version   Release: 1.2.0RC3
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_ObjectOperatorIndentSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ObjectOperatorIndentSniff implements Sniff
 {
 
 
@@ -51,7 +57,7 @@ class Backdrop_Sniffs_WhiteSpace_ObjectOperatorIndentSniff implements PHP_CodeSn
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -16,7 +16,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ObjectOperatorSpacingSniff implements Sniff
 {
 
 
@@ -41,11 +48,11 @@ class Backdrop_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeS
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr - 1, null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
         // Line breaks are allowed before an object operator.
         if ($tokens[$stackPtr]['line'] === $tokens[$prevToken]['line']
             && $prevToken < ($stackPtr - 1)
@@ -55,7 +62,7 @@ class Backdrop_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeS
         }
 
         $nextType = $tokens[($stackPtr + 1)]['code'];
-        if (in_array($nextType, PHP_CodeSniffer_Tokens::$emptyTokens) === true) {
+        if (in_array($nextType, Tokens::$emptyTokens) === true) {
             $error = 'Space found after object operator';
             $phpcsFile->addError($error, $stackPtr, 'After');
         }
@@ -64,5 +71,3 @@ class Backdrop_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeS
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/OpenBracketSpacingSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/OpenBracketSpacingSniff.php
@@ -17,7 +17,13 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_OpenBracketSpacingSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class OpenBracketSpacingSniff implements Sniff
 {
 
     /**
@@ -55,7 +61,7 @@ class Backdrop_Sniffs_WhiteSpace_OpenBracketSpacingSniff implements PHP_CodeSnif
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -83,5 +89,3 @@ class Backdrop_Sniffs_WhiteSpace_OpenBracketSpacingSniff implements PHP_CodeSnif
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -18,7 +18,12 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_OperatorSpacingSniff extends Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff as Squiz_OperatorSpacingSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+class OperatorSpacingSniff extends Squiz_OperatorSpacingSniff
 {
 
 
@@ -29,9 +34,9 @@ class Backdrop_Sniffs_WhiteSpace_OperatorSpacingSniff extends Squiz_Sniffs_White
      */
     public function register()
     {
-        $comparison = PHP_CodeSniffer_Tokens::$comparisonTokens;
-        $operators  = PHP_CodeSniffer_Tokens::$operators;
-        $assignment = PHP_CodeSniffer_Tokens::$assignmentTokens;
+        $comparison = Tokens::$comparisonTokens;
+        $operators  = Tokens::$operators;
+        $assignment = Tokens::$assignmentTokens;
 
         return array_unique(
             array_merge($comparison, $operators, $assignment)
@@ -41,5 +46,3 @@ class Backdrop_Sniffs_WhiteSpace_OperatorSpacingSniff extends Squiz_Sniffs_White
 
 
 }//end class
-
-?>

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -19,7 +19,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ScopeClosingBraceSniff implements Sniff
 {
 
     /**
@@ -37,7 +44,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniff
      */
     public function register()
     {
-        return PHP_CodeSniffer_Tokens::$scopeOpeners;
+        return Tokens::$scopeOpeners;
 
     }//end register()
 
@@ -51,7 +58,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -108,7 +115,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniff
                 || $tokens[$lastContent]['code'] !== T_OPEN_CURLY_BRACKET)
             {
                 $error = 'Closing brace must be on a line by itself';
-                $phpcsFile->addError($error, $scopeEnd);
+                $phpcsFile->addError($error, $scopeEnd, 'ClosingBrace');
             }
             return;
         }

--- a/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/coder_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -21,7 +21,14 @@
  * @package  PHP_CodeSniffer
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sniff
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ScopeIndentSniff implements Sniff
 {
 
     /**
@@ -56,7 +63,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
      */
     public function register()
     {
-        return PHP_CodeSniffer_Tokens::$scopeOpeners;
+        return Tokens::$scopeOpeners;
 
     }//end register()
 
@@ -70,7 +77,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -82,7 +89,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
 
         if ($tokens[$stackPtr]['code'] === T_ELSE) {
             $next = $phpcsFile->findNext(
-                PHP_CodeSniffer_Tokens::$emptyTokens,
+                Tokens::$emptyTokens,
                 ($stackPtr + 1),
                 null,
                 true
@@ -98,7 +105,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
         $firstToken = $stackPtr;
         for ($i = $stackPtr; $i >= 0; $i--) {
             // Record the first code token on the line.
-            if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$emptyTokens) === false) {
+            if (in_array($tokens[$i]['code'], Tokens::$emptyTokens) === false) {
                 $firstToken = $i;
             }
 
@@ -147,7 +154,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
 
             // If this token is another scope, skip it as it will be handled by
             // another call to this sniff.
-            if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$scopeOpeners) === true) {
+            if (in_array($tokens[$i]['code'], Tokens::$scopeOpeners) === true) {
                 if (isset($tokens[$i]['scope_opener']) === true) {
                     $i = $tokens[$i]['scope_closer'];
 
@@ -155,7 +162,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
                     // of the closer and should also be ignored. This most commonly happens with
                     // CASE statements that end with "break;", where we don't want to stop
                     // ignoring at the break, but rather at the semi-colon.
-                    $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($i + 1), null, true);
+                    $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
                     if ($tokens[$nextToken]['code'] === T_SEMICOLON) {
                         $i = $nextToken;
                     }
@@ -220,8 +227,8 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
                 // Check to see if this constant string spans multiple lines.
                 // If so, then make sure that the strings on lines other than the
                 // first line are indented appropriately, based on their whitespace.
-                if (in_array($tokens[$firstToken]['code'], PHP_CodeSniffer_Tokens::$stringTokens) === true) {
-                    if (in_array($tokens[($firstToken - 1)]['code'], PHP_CodeSniffer_Tokens::$stringTokens) === true) {
+                if (in_array($tokens[$firstToken]['code'], Tokens::$stringTokens) === true) {
+                    if (in_array($tokens[($firstToken - 1)]['code'], Tokens::$stringTokens) === true) {
                         // If we find a string that directly follows another string
                         // then its just a string that spans multiple lines, so we
                         // don't need to check for indenting.
@@ -231,7 +238,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
 
                 // This is a special condition for T_DOC_COMMENT and C-style
                 // comments, which contain whitespace between each line.
-                if (in_array($tokens[$firstToken]['code'], PHP_CodeSniffer_Tokens::$commentTokens) === true) {
+                if (in_array($tokens[$firstToken]['code'], Tokens::$commentTokens) === true) {
                     $content = trim($tokens[$firstToken]['content']);
                     if (preg_match('|^/\*|', $content) !== 0) {
                         // Check to see if the end of the comment is on the same line
@@ -269,7 +276,7 @@ class Backdrop_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sni
                 if ($column >= $indent) {
                     // Ignore code between paranthesis (multi line function calls or
                     // arrays) and multi line statements.
-                    $before = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($firstToken - 1), $scopeOpener, true);
+                    $before = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($firstToken - 1), $scopeOpener, true);
                     if ($before !== $scopeOpener
                         && $tokens[$before]['code'] !== T_SEMICOLON
                         && $tokens[$before]['code'] !== T_CLOSE_CURLY_BRACKET

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.2.0",
-        "squizlabs/php_codesniffer": ">=1.4.6,<2.0.0"
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/composer.lock
+++ b/composer.lock
@@ -1,67 +1,43 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "946f2183873b8997fbb365d1acdbe781",
+    "content-hash": "fd963c99808ffd76f1977dd1e1d37f08",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "1.5.6",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6f3e42d311b882b25b4d409d23a289f4d3b803d5"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6f3e42d311b882b25b4d409d23a289f4d3b803d5",
-                "reference": "6f3e42d311b882b25b4d409d23a289f4d3b803d5",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
+                "ext-simplexml": "*",
                 "ext-tokenizer": "*",
-                "php": ">=5.1.2"
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
             },
-            "suggest": {
-                "phpunit/php-timer": "dev-master"
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-phpcs-fixer": "2.0.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/CommentParser/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -73,13 +49,13 @@
                     "role": "lead"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-04 22:32:15"
+            "time": "2020-08-10T04:50:15+00:00"
         }
     ],
     "packages-dev": [
@@ -142,7 +118,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-09-02 10:13:14"
+            "time": "2014-09-02T10:13:14+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -189,7 +165,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-04-02 05:19:05"
+            "time": "2015-04-02T05:19:05+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -233,7 +209,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2014-01-30T17:20:04+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -277,7 +253,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2013-08-02T07:42:54+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -327,7 +303,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-03-03 05:10:30"
+            "time": "2014-03-03T05:10:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -400,7 +376,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-10-17 09:04:17"
+            "time": "2014-10-17T09:04:17+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -449,7 +425,8 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2013-01-13 10:24:48"
+            "abandoned": true,
+            "time": "2013-01-13T10:24:48+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -499,7 +476,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:54:10"
+            "time": "2015-03-30T15:54:10+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
This PR updates the sniffs in Coder Review to work with phpcs ^3.0. As a side effect of using a version pf phpcs greater than 2.*, we have a minimum PHP version requirement of 5.4.

Fixes #12.